### PR TITLE
Add New LanguageChart Layouts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,14 +142,64 @@ Add an entry to the `BADGE_STYLES` array so it appears in the visual editor badg
 
 ---
 
+## Adding a New Language Layout Style
+
+To add a new language chart layout style:
+
+**1. Add the layout style to `src/lib/types.ts`**
+
+- Add the new style entry to the `LANG_CHART_LAYOUTS` constant. This acts as the **single source of truth** for all supported language chart layouts. 
+
+```ts
+export const LANG_CHART_LAYOUTS = [
+  "donut",
+  "donut_vertical",
+  "compact",
+  "bar",
+  "stacked",
+  "horizontal_list",
+  "vertical_list",
+  "grid",
+  "pie_chart", // Newly added style
+] as const;
+```
+
+**2. Implement the renderer in `src/lib/svg.ts`**
+
+- Add the renderer function for the new layout.
+
+```ts
+function renderPieLanguageChart() {
+  // your Renderer implementation
+}
+```
+
+**3. Register the new layout**
+
+- Add the layout handler inside `renderLanguageChart()`.
+
+```ts
+export function renderLanguageChart() {
+  // Existing code
+
+  if (options.layout === "pie_chart") {
+    return renderPieLanguageChart();
+  }
+}
+```
+
 ## Other Ways to Contribute
 
-| Area | Where to look |
-|---|---|
-| Bug fixes | [Open an issue](https://github.com/rowkav09/GitHub-profile-stats/issues) first so we can confirm it, then submit a PR |
-| New card layouts | `src/lib/svg.ts` — add a new render function and wire it up via `options.size` |
-| Badge styles | `src/app/api/badge/badge-svg.ts` — add a config entry and update the page picker |
-| Visual editor improvements | `src/components/CardPreview.tsx` and `src/components/VisualBuilder.tsx` |
-| Homepage / hero section | `src/components/HeroCard.tsx` and `src/app/page.tsx` |
-| API / caching | `src/app/api/` |
-| Docs | Edit `README.md` directly |
+| Area                       | Where to look                                                                                                         |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Bug fixes                  | [Open an issue](https://github.com/rowkav09/GitHub-profile-stats/issues) first so we can confirm it, then submit a PR |
+| New card layouts           | `src/lib/svg.ts` — add a new render function and wire it up via `options.size`                                        |
+| Badge styles               | `src/app/api/badge/badge-svg.ts` — add a config entry and update the page picker                                      |
+| Visual editor improvements | `src/components/CardPreview.tsx` and `src/components/VisualBuilder.tsx`                                               |
+| Homepage / hero section    | `src/components/HeroCard.tsx` and `src/app/page.tsx`                                                                  |
+| API / caching              | `src/app/api/`                                                                                                        |
+| Docs                       | Edit `README.md` directly                                                                                             |
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Free, real-time GitHub stat cards, badges, and charts -- drop a URL into your RE
 **Standard card**
 
 [![](https://ghstats.dev/api/card?username=rowkav09&theme=tokyonight)](https://github.com/rowkav09/GitHub-profile-stats)
+
 ```
 [![](https://ghstats.dev/api/card?username=YOUR_USERNAME&theme=tokyonight)](https://github.com/rowkav09/GitHub-profile-stats)
 ```
@@ -34,25 +35,34 @@ Free, real-time GitHub stat cards, badges, and charts -- drop a URL into your RE
 [![](https://ghstats.dev/api/card?username=rowkav09&theme=radical&size=compact&compact_count=3)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/card?username=rowkav09&theme=catppuccin&size=compact&compact_count=4)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/card?username=rowkav09&theme=forest&size=compact&compact_count=6)](https://github.com/rowkav09/GitHub-profile-stats)
+
 ```
 [![](https://ghstats.dev/api/card?username=YOUR_USERNAME&theme=radical&size=compact&compact_count=3)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/card?username=YOUR_USERNAME&theme=catppuccin&size=compact&compact_count=4)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/card?username=YOUR_USERNAME&theme=forest&size=compact&compact_count=6)](https://github.com/rowkav09/GitHub-profile-stats)
 ```
 
-**Languages (bar, stacked, grid, horizontal list, vertical list)**
+**Languages (bar, stacked, grid, horizontal list, vertical list, donut, vertical donut, compact)**
 
 [![](https://ghstats.dev/api/langs?username=rowkav09&theme=dracula&layout=bar)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/langs?username=rowkav09&theme=ocean&layout=stacked)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/langs?username=rowkav09&theme=radical&layout=horizontal_list)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/langs?username=rowkav09&theme=catppuccin&layout=vertical_list)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/langs?username=rowkav09&theme=tokyonight&layout=grid)](https://github.com/rowkav09/GitHub-profile-stats)
-```
+[![](https://ghstats.dev/api/langs?username=rowkav09&theme=tokyonight&layout=donut)](https://github.com/rowkav09/GitHub-profile-stats)
+[![](https://ghstats.dev/api/langs?username=rowkav09&theme=tokyonight&layout=vertical_donut)](https://github.com/rowkav09/GitHub-profile-stats)
+[![](https://ghstats.dev/api/langs?username=rowkav09&theme=tokyonight&layout=compact)](https://github.com/rowkav09/GitHub-profile-stats)
+
+```bash
 [![](https://ghstats.dev/api/langs?username=YOUR_USERNAME&theme=dracula&layout=bar)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/langs?username=YOUR_USERNAME&theme=ocean&layout=stacked)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/langs?username=YOUR_USERNAME&theme=radical&layout=horizontal_list)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/langs?username=YOUR_USERNAME&theme=catppuccin&layout=vertical_list)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/langs?username=YOUR_USERNAME&theme=tokyonight&layout=grid)](https://github.com/rowkav09/GitHub-profile-stats)
+[![](https://ghstats.dev/api/langs?username=YOUR_USERNAME&theme=tokyonight&layout=donut)](https://github.com/rowkav09/GitHub-profile-stats)
+[![](https://ghstats.dev/api/langs?username=YOUR_USERNAME&theme=tokyonight&layout=donut_vertical)](https://github.com/rowkav09/GitHub-profile-stats)
+[![](https://ghstats.dev/api/langs?username=YOUR_USERNAME&theme=tokyonight&layout=compact)](https://github.com/rowkav09/GitHub-profile-stats)
+
 ```
 
 **Mini badges (drop anywhere)**
@@ -63,6 +73,7 @@ Any metric, any colour, any style -- perfect for sprinkling through a README.
 [![](https://ghstats.dev/api/mini?username=rowkav09&metric=commits&color=0ea5e9&style=for-the-badge)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/mini?username=rowkav09&metric=streak&color=f97316&style=for-the-badge)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/mini?username=rowkav09&metric=followers&label=Community&color=22c55e&style=for-the-badge)](https://github.com/rowkav09/GitHub-profile-stats)
+
 ```
 [![](https://ghstats.dev/api/mini?username=YOUR_USERNAME&metric=stars&style=for-the-badge)](https://github.com/rowkav09/GitHub-profile-stats)
 [![](https://ghstats.dev/api/mini?username=YOUR_USERNAME&metric=commits&color=0ea5e9&style=for-the-badge)](https://github.com/rowkav09/GitHub-profile-stats)
@@ -74,24 +85,26 @@ Pass `label=...` to override the default label text and `style=...` to switch be
 
 **Badge styles -- pick a look**
 
-| Style | Preview |
-| --- | --- |
-| `flat` | ![](https://ghstats.dev/api/badge?style=flat) |
-| `flat-square` | ![](https://ghstats.dev/api/badge?style=flat-square) |
+| Style           | Preview                                                |
+| --------------- | ------------------------------------------------------ |
+| `flat`          | ![](https://ghstats.dev/api/badge?style=flat)          |
+| `flat-square`   | ![](https://ghstats.dev/api/badge?style=flat-square)   |
 | `for-the-badge` | ![](https://ghstats.dev/api/badge?style=for-the-badge) |
-| `plastic` | ![](https://ghstats.dev/api/badge?style=plastic) |
-| `minimal` | ![](https://ghstats.dev/api/badge?style=minimal) |
+| `plastic`       | ![](https://ghstats.dev/api/badge?style=plastic)       |
+| `minimal`       | ![](https://ghstats.dev/api/badge?style=minimal)       |
 
 Apply with `?style=for-the-badge` on `/api/mini` or `/api/badge`. Works alongside `color` and `label`.
 
 **Activity sparkline (7--90 days)**
 
 [![](https://ghstats.dev/api/sparkline?username=rowkav09&days=30&width=420)](https://github.com/rowkav09/GitHub-profile-stats)
+
 ```
 [![](https://ghstats.dev/api/sparkline?username=YOUR_USERNAME&days=30&width=420)](https://github.com/rowkav09/GitHub-profile-stats)
 ```
 
 **Quick colour override**
+
 ```
 https://ghstats.dev/api/card?username=YOUR_USERNAME&bg=0f0f23&text=cccccc&title_color=ffff66&icon_color=ff6644
 ```
@@ -100,8 +113,8 @@ https://ghstats.dev/api/card?username=YOUR_USERNAME&bg=0f0f23&text=cccccc&title_
 
 ## 30-second setup
 
-1) Create a public repo named **your-username** on GitHub and add a `README.md`.
-2) Paste an embed from the gallery above. Done.
+1. Create a public repo named **your-username** on GitHub and add a `README.md`.
+2. Paste an embed from the gallery above. Done.
 
 Need tweaks? Use the on-page editor to toggle stats, themes, borders, titles, and copy Markdown/HTML instantly.
 
@@ -110,6 +123,7 @@ Need tweaks? Use the on-page editor to toggle stats, themes, borders, titles, an
 ## Options cheat sheet
 
 **Card ( /api/card )**
+
 - `username` (required)
 - `theme` default `default`
 - Layout: `size=default|compact`, `compact_count=3|4|6`, `show_emoji=true`
@@ -117,23 +131,28 @@ Need tweaks? Use the on-page editor to toggle stats, themes, borders, titles, an
 - Styling: `bg`, `text`, `title_color`, `icon_color`, `border_color`, `border_radius`, `custom_title`, `order`
 
 **Languages ( /api/langs )**
+
 - `layout=bar|stacked|horizontal_list|vertical_list|grid`, `max_langs` (1--12)
 - `hide_border`, `hide_title`, `custom_title`, `border_radius`, theme overrides as above
 
 **Mini badges ( /api/mini )**
+
 - `metric=stars|commits|prs|issues|hours|streak|week|followers|repos|contributions`
 - `label` (override text), `color` (value side), `theme` (for errors)
 - `style=flat|flat-square|for-the-badge|plastic|minimal` (default `flat`)
 
 **Counter badge ( /api/badge )**
+
 - `style=flat|flat-square|for-the-badge|plastic|minimal` (default `flat`)
 
 **Visits badge ( /api/visits )**
+
 - `style=flat|flat-square|for-the-badge|plastic|minimal` (default `flat`)
 
 > Note: `hours` is currently WIP and is an estimate, not exact tracked coding time.
 
 **Sparkline ( /api/sparkline )**
+
 - `days` (7--90), `width` (180--800), `height` (40--240), `line_color`, `fill_color`, `title`, `hide_border`, `border_radius`
 
 ---

--- a/src/app/api/langs/route.ts
+++ b/src/app/api/langs/route.ts
@@ -48,7 +48,13 @@ export async function GET(request: NextRequest) {
               ? "grid"
               : params.get("layout") === "donut"
                 ? "donut"
-                : "bar",
+                : params.get("layout") === "donut_vertical"
+                  ? "donut_vertical"
+                  : params.get("layout") === "pie_chart"
+                    ? "pie_chart"
+                    : params.get("layout") === "hidden"
+                      ? "hidden"
+                      : "bar",
   };
 
   const headers = {

--- a/src/app/api/langs/route.ts
+++ b/src/app/api/langs/route.ts
@@ -3,10 +3,21 @@ import { fetchLanguageStats } from "@/lib/github";
 import { renderLanguageChart, renderErrorCard } from "@/lib/svg";
 import { resolveTheme } from "@/lib/themes";
 import { sanitizeUsername, sanitizeHexParam } from "@/lib/sanitize";
-import { LangChartOptions } from "@/lib/types";
+import {
+  LangChartOptions,
+  LangChartLayout,
+  LANG_CHART_LAYOUTS,
+} from "@/lib/types";
 import { getCacheHeaders } from "@/lib/cache";
 
 export const dynamic = "force-dynamic";
+
+// Parses & validates a layout query param against LANG_CHART_LAYOUTS, defaulting to "bar".
+function parseLangLayout(value: string | null): LangChartLayout {
+  return (LANG_CHART_LAYOUTS as readonly string[]).includes(value ?? "")
+    ? (value as LangChartLayout)
+    : "bar";
+}
 
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
@@ -37,22 +48,7 @@ export async function GET(request: NextRequest) {
       50,
     ),
     max_langs: maxLangs,
-    layout:
-      params.get("layout") === "stacked"
-        ? "stacked"
-        : params.get("layout") === "horizontal_list"
-          ? "horizontal_list"
-          : params.get("layout") === "vertical_list"
-            ? "vertical_list"
-            : params.get("layout") === "grid"
-              ? "grid"
-              : params.get("layout") === "donut"
-                ? "donut"
-                : params.get("layout") === "donut_vertical"
-                  ? "donut_vertical"
-                  : params.get("layout") === "compact"
-                    ? "compact"
-                    : "bar",
+    layout: parseLangLayout(params.get("layout")),
   };
 
   const headers = {

--- a/src/app/api/langs/route.ts
+++ b/src/app/api/langs/route.ts
@@ -50,11 +50,9 @@ export async function GET(request: NextRequest) {
                 ? "donut"
                 : params.get("layout") === "donut_vertical"
                   ? "donut_vertical"
-                  : params.get("layout") === "pie_chart"
-                    ? "pie_chart"
-                    : params.get("layout") === "hidden"
-                      ? "hidden"
-                      : "bar",
+                  : params.get("layout") === "compact"
+                    ? "compact"
+                    : "bar",
   };
 
   const headers = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,7 +96,7 @@ const PARAMS = [
     name: "layout",
     type: "string",
     default: '"bar"',
-    desc: 'Languages chart style — "bar", "stacked", "horizontal_list", "vertical_list", or "grid"',
+    desc: 'Languages chart style — "bar", "stacked", "horizontal_list", "vertical_list", "grid", "donut", "donut_vertical" or "compact"',
   },
   {
     name: "max_langs",
@@ -113,11 +113,31 @@ const PARAMS = [
 ];
 
 const BADGE_STYLES = [
-  { key: "flat", label: "Flat", desc: "Default shields.io look with subtle gradient and rounded corners." },
-  { key: "flat-square", label: "Flat Square", desc: "Same as Flat, but with sharp square corners." },
-  { key: "for-the-badge", label: "For The Badge", desc: "Large, bold, uppercase — built to stand out in a README." },
-  { key: "plastic", label: "Plastic", desc: "Glossy plastic finish with a top-light, bottom-shadow gradient." },
-  { key: "minimal", label: "Minimal", desc: "Just text on a transparent background — clean and unobtrusive." },
+  {
+    key: "flat",
+    label: "Flat",
+    desc: "Default shields.io look with subtle gradient and rounded corners.",
+  },
+  {
+    key: "flat-square",
+    label: "Flat Square",
+    desc: "Same as Flat, but with sharp square corners.",
+  },
+  {
+    key: "for-the-badge",
+    label: "For The Badge",
+    desc: "Large, bold, uppercase — built to stand out in a README.",
+  },
+  {
+    key: "plastic",
+    label: "Plastic",
+    desc: "Glossy plastic finish with a top-light, bottom-shadow gradient.",
+  },
+  {
+    key: "minimal",
+    label: "Minimal",
+    desc: "Just text on a transparent background — clean and unobtrusive.",
+  },
 ];
 
 const HIDE_KEYS = [
@@ -151,7 +171,9 @@ export default function Home() {
             rel="noopener noreferrer"
             className="flex items-center gap-1.5 text-sm text-[#8b949e] hover:text-[#c9d1d9] transition-colors"
           >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+            </svg>
             View on GitHub
           </a>
         </div>
@@ -163,11 +185,18 @@ export default function Home() {
           <h1 className="text-4xl font-bold tracking-tight sm:text-5xl animate-slide-up">
             GitHub Stats for Your README
           </h1>
-          <p className="mt-4 text-lg text-[#8b949e] max-w-2xl mx-auto animate-slide-up" style={{ animationDelay: '80ms' }}>
-            One line in your README — that&apos;s it. Your stats card stays up to date automatically.
-            Pick a theme, hide what you don&apos;t need, and you&apos;re done.
+          <p
+            className="mt-4 text-lg text-[#8b949e] max-w-2xl mx-auto animate-slide-up"
+            style={{ animationDelay: "80ms" }}
+          >
+            One line in your README — that&apos;s it. Your stats card stays up
+            to date automatically. Pick a theme, hide what you don&apos;t need,
+            and you&apos;re done.
           </p>
-          <div className="mt-8 flex justify-center gap-4 animate-slide-up" style={{ animationDelay: '160ms' }}>
+          <div
+            className="mt-8 flex justify-center gap-4 animate-slide-up"
+            style={{ animationDelay: "160ms" }}
+          >
             <a
               href="#try"
               className="rounded-lg bg-[#238636] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#2ea043] transition-all duration-200 hover:shadow-lg hover:shadow-[#238636]/20"
@@ -181,7 +210,10 @@ export default function Home() {
               Documentation
             </a>
           </div>
-          <div className="mt-12 animate-slide-up" style={{ animationDelay: '240ms' }}>
+          <div
+            className="mt-12 animate-slide-up"
+            style={{ animationDelay: "240ms" }}
+          >
             <HeroCard />
           </div>
         </div>
@@ -195,19 +227,42 @@ export default function Home() {
           {/* Step 1 */}
           <div className="mt-6">
             <h3 className="text-lg font-semibold text-[#c9d1d9] flex items-center gap-2">
-              <span className="flex items-center justify-center w-6 h-6 rounded-full bg-[#238636] text-xs font-bold text-white">1</span>
+              <span className="flex items-center justify-center w-6 h-6 rounded-full bg-[#238636] text-xs font-bold text-white">
+                1
+              </span>
               Create your profile README
             </h3>
             <p className="mt-2 text-sm text-[#8b949e] ml-8">
-              GitHub displays a special README on your profile when you create a repo with the same name as your username.
+              GitHub displays a special README on your profile when you create a
+              repo with the same name as your username.
             </p>
             <ol className="mt-2 ml-8 text-sm text-[#8b949e] list-decimal list-inside space-y-1">
-              <li>Go to{" "}
-                <a href="https://github.com/new" target="_blank" rel="noopener noreferrer" className="text-[#58a6ff] hover:underline">github.com/new</a>
+              <li>
+                Go to{" "}
+                <a
+                  href="https://github.com/new"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[#58a6ff] hover:underline"
+                >
+                  github.com/new
+                </a>
               </li>
-              <li>Set the repo name to <strong className="text-[#c9d1d9]">your exact username</strong></li>
-              <li>Make it <strong className="text-[#c9d1d9]">public</strong> and check <strong className="text-[#c9d1d9]">&quot;Add a README file&quot;</strong></li>
-              <li>Click <strong className="text-[#c9d1d9]">Create repository</strong></li>
+              <li>
+                Set the repo name to{" "}
+                <strong className="text-[#c9d1d9]">your exact username</strong>
+              </li>
+              <li>
+                Make it <strong className="text-[#c9d1d9]">public</strong> and
+                check{" "}
+                <strong className="text-[#c9d1d9]">
+                  &quot;Add a README file&quot;
+                </strong>
+              </li>
+              <li>
+                Click{" "}
+                <strong className="text-[#c9d1d9]">Create repository</strong>
+              </li>
             </ol>
             <p className="mt-2 text-xs text-[#484f58] ml-8">
               Already have a profile README? Skip to step 2.
@@ -217,18 +272,26 @@ export default function Home() {
           {/* Step 2 */}
           <div className="mt-8">
             <h3 className="text-lg font-semibold text-[#c9d1d9] flex items-center gap-2">
-              <span className="flex items-center justify-center w-6 h-6 rounded-full bg-[#238636] text-xs font-bold text-white">2</span>
+              <span className="flex items-center justify-center w-6 h-6 rounded-full bg-[#238636] text-xs font-bold text-white">
+                2
+              </span>
               Add your stats card
             </h3>
             <p className="mt-2 text-sm text-[#8b949e] ml-8">
-              Edit the <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-[#79c0ff]">README.md</code> in your profile repo and paste:
+              Edit the{" "}
+              <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-[#79c0ff]">
+                README.md
+              </code>{" "}
+              in your profile repo and paste:
             </p>
             <pre className="mt-3 ml-8 overflow-x-auto rounded-lg border border-[#30363d] bg-[#161b22] px-5 py-4 text-sm text-[#c9d1d9]">
               {`![GitHub Stats](https://ghstats.dev/api/card?username=YOUR_USERNAME)`}
             </pre>
             <p className="mt-3 ml-8 text-sm text-[#8b949e]">
               Want a different look? Add{" "}
-              <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-[#79c0ff]">{'&theme=tokyonight'}</code>{" "}
+              <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-[#79c0ff]">
+                {"&theme=tokyonight"}
+              </code>{" "}
               or use the editor below to customise everything.
             </p>
           </div>
@@ -330,9 +393,18 @@ export default function Home() {
         <div className="mx-auto max-w-6xl px-6 py-16">
           <h2 className="text-2xl font-bold mb-2">Badge Styles</h2>
           <p className="text-[#8b949e] mb-6">
-            Pass <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-sm text-[#79c0ff]">style</code>{" "}
-            to <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-sm text-[#79c0ff]">/api/mini</code>{" "}
-            or <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-sm text-[#79c0ff]">/api/badge</code>{" "}
+            Pass{" "}
+            <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-sm text-[#79c0ff]">
+              style
+            </code>{" "}
+            to{" "}
+            <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-sm text-[#79c0ff]">
+              /api/mini
+            </code>{" "}
+            or{" "}
+            <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-sm text-[#79c0ff]">
+              /api/badge
+            </code>{" "}
             to switch the badge look.
           </p>
           <pre className="overflow-x-auto rounded-lg border border-[#30363d] bg-[#161b22] px-5 py-3 text-sm text-[#c9d1d9] mb-6">
@@ -354,7 +426,9 @@ export default function Home() {
                       <code className="rounded bg-[#161b22] px-1.5 py-0.5 text-xs text-[#79c0ff]">
                         {s.key}
                       </code>
-                      <div className="text-xs text-[#8b949e] mt-1">{s.label}</div>
+                      <div className="text-xs text-[#8b949e] mt-1">
+                        {s.label}
+                      </div>
                     </td>
                     <td className="px-4 py-3 align-top">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -364,7 +438,9 @@ export default function Home() {
                         className="h-5"
                       />
                     </td>
-                    <td className="px-4 py-3 text-[#c9d1d9] align-top">{s.desc}</td>
+                    <td className="px-4 py-3 text-[#c9d1d9] align-top">
+                      {s.desc}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -372,7 +448,6 @@ export default function Home() {
           </div>
         </div>
       </section>
-
 
       {/* ─── Footer ─── */}
       <footer className="border-t border-[#21262d] bg-[#010409]">
@@ -384,7 +459,9 @@ export default function Home() {
             rel="noopener noreferrer"
             className="flex items-center gap-1.5 text-[#8b949e] hover:text-[#c9d1d9] transition-colors"
           >
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+            </svg>
             rowkav09/GitHub-profile-stats
           </a>
         </div>

--- a/src/components/CardPreview.tsx
+++ b/src/components/CardPreview.tsx
@@ -69,7 +69,9 @@ function BadgeStylePicker({
             />
             <span
               className={`text-[10px] font-semibold uppercase tracking-wider transition-colors ${
-                isActive ? "text-[#58a6ff]" : "text-[#8b949e] group-hover:text-[#c9d1d9]"
+                isActive
+                  ? "text-[#58a6ff]"
+                  : "text-[#8b949e] group-hover:text-[#c9d1d9]"
               }`}
             >
               {opt.label}
@@ -98,12 +100,23 @@ export default function CardPreview() {
   const [compactCount, setCompactCount] = useState<3 | 4 | 6>(6);
   const [showEmoji, setShowEmoji] = useState(false);
   const [hiddenStats, setHiddenStats] = useState<string[]>([]);
-  const [statsOrder, setStatsOrder] = useState<string[]>(STAT_OPTIONS.map((s) => s.key));
+  const [statsOrder, setStatsOrder] = useState<string[]>(
+    STAT_OPTIONS.map((s) => s.key),
+  );
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   // Languages options
-  const [langLayout, setLangLayout] = useState<"bar" | "stacked" | "horizontal_list" | "vertical_list" | "grid">("bar");
+  const [langLayout, setLangLayout] = useState<
+    | "bar"
+    | "stacked"
+    | "horizontal_list"
+    | "vertical_list"
+    | "grid"
+    | "donut"
+    | "donut_vertical"
+    | "hidden"
+  >("bar");
   const [maxLangs, setMaxLangs] = useState(8);
 
   // Mini badge options
@@ -175,12 +188,15 @@ export default function CardPreview() {
       if (borderRadius !== "4.5") p.set("border_radius", borderRadius);
       if (customTitle.trim()) p.set("custom_title", customTitle.trim());
       if (size === "compact") p.set("size", "compact");
-      if (size === "compact" && compactCount !== 6) p.set("compact_count", String(compactCount));
+      if (size === "compact" && compactCount !== 6)
+        p.set("compact_count", String(compactCount));
       if (size === "compact" && showEmoji) p.set("show_emoji", "true");
       if (hiddenStats.length > 0) p.set("hide", hiddenStats.join(","));
 
       const visibleOrder = statsOrder.filter((k) => !hiddenStats.includes(k));
-      const defaultVisible = STAT_OPTIONS.map((s) => s.key).filter((k) => !hiddenStats.includes(k));
+      const defaultVisible = STAT_OPTIONS.map((s) => s.key).filter(
+        (k) => !hiddenStats.includes(k),
+      );
       const isReordered =
         visibleOrder.length === defaultVisible.length &&
         visibleOrder.some((k, i) => k !== defaultVisible[i]);
@@ -282,7 +298,9 @@ export default function CardPreview() {
         <div className="flex items-center justify-between flex-wrap gap-3">
           <div>
             <h2 className="text-2xl font-bold">Try it out</h2>
-            <p className="text-sm text-[#8b949e]">Generate your embed, preview it, then copy a single line.</p>
+            <p className="text-sm text-[#8b949e]">
+              Generate your embed, preview it, then copy a single line.
+            </p>
           </div>
           <div className="flex items-center gap-2 text-xs text-[#8b949e] bg-[#0b1117] border border-[#30363d] rounded-lg px-3 py-1.5">
             <span className="h-2 w-2 rounded-full bg-[#238636]" />
@@ -296,12 +314,14 @@ export default function CardPreview() {
             <div>
               <label className="label-text">Embed Type</label>
               <div className="mt-2 inline-flex rounded-xl border border-[#30363d] bg-[#0d1117] p-[3px] flex-wrap">
-                {([
-                  { key: "card", label: "Stats Card" },
-                  { key: "langs", label: "Languages" },
-                  { key: "mini", label: "Mini Badge" },
-                  { key: "sparkline", label: "Sparkline" },
-                ] as const).map((opt) => (
+                {(
+                  [
+                    { key: "card", label: "Stats Card" },
+                    { key: "langs", label: "Languages" },
+                    { key: "mini", label: "Mini Badge" },
+                    { key: "sparkline", label: "Sparkline" },
+                  ] as const
+                ).map((opt) => (
                   <button
                     key={opt.key}
                     onClick={() => setEmbedType(opt.key)}
@@ -332,7 +352,10 @@ export default function CardPreview() {
               <>
                 <div>
                   <label className="label-text">
-                    Custom Title <span className="text-[#484f58] font-normal">(optional)</span>
+                    Custom Title{" "}
+                    <span className="text-[#484f58] font-normal">
+                      (optional)
+                    </span>
                   </label>
                   <input
                     type="text"
@@ -345,7 +368,10 @@ export default function CardPreview() {
 
                 <div>
                   <label className="label-text">
-                    Border Radius: <span className="text-[#58a6ff] font-semibold">{borderRadius}</span>
+                    Border Radius:{" "}
+                    <span className="text-[#58a6ff] font-semibold">
+                      {borderRadius}
+                    </span>
                   </label>
                   <input
                     type="range"
@@ -371,7 +397,7 @@ export default function CardPreview() {
                             : "text-[#8b949e] hover:text-[#c9d1d9]"
                         }`}
                       >
-                        {s === "default" ? "Standard" : "Compact"}
+                        {s === "default" ? "Standard" : "Hidden"}
                       </button>
                     ))}
                   </div>
@@ -396,7 +422,9 @@ export default function CardPreview() {
                           </button>
                         ))}
                       </div>
-                      <p className="mt-1.5 text-[11px] text-[#484f58]">Shows the first {compactCount} visible stats in order</p>
+                      <p className="mt-1.5 text-[11px] text-[#484f58]">
+                        Shows the first {compactCount} visible stats in order
+                      </p>
                     </div>
                     <label className="toggle-label">
                       <input
@@ -411,10 +439,23 @@ export default function CardPreview() {
                 )}
 
                 <div className="flex flex-wrap gap-x-5 gap-y-2">
-                  {[{ label: "Show Icons", checked: showIcons, set: setShowIcons },
+                  {[
+                    {
+                      label: "Show Icons",
+                      checked: showIcons,
+                      set: setShowIcons,
+                    },
                     { label: "Show Ring", checked: showRing, set: setShowRing },
-                    { label: "Hide Border", checked: hideBorder, set: setHideBorder },
-                    { label: "Hide Title", checked: hideTitle, set: setHideTitle },
+                    {
+                      label: "Hide Border",
+                      checked: hideBorder,
+                      set: setHideBorder,
+                    },
+                    {
+                      label: "Hide Title",
+                      checked: hideTitle,
+                      set: setHideTitle,
+                    },
                   ].map((t) => (
                     <label key={t.label} className="toggle-label">
                       <input
@@ -446,8 +487,12 @@ export default function CardPreview() {
                 {advancedMode && (
                   <div className="space-y-3 rounded-xl border border-[#30363d]/60 bg-[#0d1117] px-4 py-4">
                     <div className="flex items-center justify-between">
-                      <label className="label-text mb-0">Reorder & hide stats</label>
-                      <span className="text-[11px] text-[#484f58]">Drag to reorder, click to hide</span>
+                      <label className="label-text mb-0">
+                        Reorder & hide stats
+                      </label>
+                      <span className="text-[11px] text-[#484f58]">
+                        Drag to reorder, click to hide
+                      </span>
                     </div>
                     <div className="space-y-2">
                       {statsOrder.map((key, index) => {
@@ -458,17 +503,21 @@ export default function CardPreview() {
                           <div
                             key={key}
                             className={`flex items-center justify-between gap-3 rounded-lg border border-[#30363d] bg-[#0d1117] px-3 py-2 text-sm text-[#c9d1d9] ${
-                              dragOverIndex === index ? "border-[#58a6ff]/60 bg-[#0f1621]" : ""
+                              dragOverIndex === index
+                                ? "border-[#58a6ff]/60 bg-[#0f1621]"
+                                : ""
                             }`}
                             draggable
                             onDragStart={() => setDragIndex(index)}
                             onDragOver={(e) => {
                               e.preventDefault();
-                              if (dragOverIndex !== index) setDragOverIndex(index);
+                              if (dragOverIndex !== index)
+                                setDragOverIndex(index);
                             }}
                             onDrop={(e) => {
                               e.preventDefault();
-                              if (dragIndex !== null && dragIndex !== index) moveStat(dragIndex, index);
+                              if (dragIndex !== null && dragIndex !== index)
+                                moveStat(dragIndex, index);
                               setDragIndex(null);
                               setDragOverIndex(null);
                             }}
@@ -478,8 +527,16 @@ export default function CardPreview() {
                             }}
                           >
                             <div className="flex items-center gap-3">
-                              <span className="cursor-grab text-[#8b949e]">⋮⋮</span>
-                              <span className={hidden ? "line-through text-[#484f58]" : ""}>{stat.label}</span>
+                              <span className="cursor-grab text-[#8b949e]">
+                                ⋮⋮
+                              </span>
+                              <span
+                                className={
+                                  hidden ? "line-through text-[#484f58]" : ""
+                                }
+                              >
+                                {stat.label}
+                              </span>
                             </div>
                             <button
                               onClick={() => toggleStat(key)}
@@ -504,8 +561,20 @@ export default function CardPreview() {
               <div className="space-y-4 rounded-xl border border-[#30363d]/60 bg-[#0d1117] px-4 py-4">
                 <div>
                   <label className="label-text">Layout</label>
-                  <div className="mt-2 inline-flex rounded-xl border border-[#30363d] bg-[#161b22] p-[3px]">
-                    {(["bar", "stacked", "horizontal_list", "vertical_list", "grid"] as const).map((opt) => (
+                  <div className="mt-2 grid grid-cols-5 rounded-xl border border-[#30363d] bg-[#161b22] p-[3px]">
+                    {" "}
+                    {(
+                      [
+                        "donut",
+                        "donut_vertical",
+                        "hidden",
+                        "bar",
+                        "stacked",
+                        "horizontal_list",
+                        "vertical_list",
+                        "grid",
+                      ] as const
+                    ).map((opt) => (
                       <button
                         key={opt}
                         onClick={() => setLangLayout(opt)}
@@ -515,14 +584,31 @@ export default function CardPreview() {
                             : "text-[#8b949e] hover:text-[#c9d1d9]"
                         }`}
                       >
-                        {opt === "bar" ? "Bar" : opt === "stacked" ? "Stacked" : opt === "horizontal_list" ? "Horizontal List" : opt === "vertical_list" ? "Vertical List" : "Grid"}
+                        {opt === "bar"
+                          ? "Bar"
+                          : opt === "stacked"
+                            ? "Stacked"
+                            : opt === "horizontal_list"
+                              ? "Horizontal List"
+                              : opt === "vertical_list"
+                                ? "Vertical List"
+                                : opt === "grid"
+                                  ? "Grid"
+                                  : opt === "donut"
+                                    ? "Donut"
+                                    : opt === "donut_vertical"
+                                      ? "Donut Vertical"
+                                      : "Compact"}
                       </button>
                     ))}
                   </div>
                 </div>
                 <div>
                   <label className="label-text">
-                    Max languages: <span className="text-[#58a6ff] font-semibold">{maxLangs}</span>
+                    Max languages:{" "}
+                    <span className="text-[#58a6ff] font-semibold">
+                      {maxLangs}
+                    </span>
                   </label>
                   <input
                     type="range"
@@ -534,8 +620,18 @@ export default function CardPreview() {
                   />
                 </div>
                 <div className="flex flex-wrap gap-x-5 gap-y-2">
-                  {[{ label: "Hide Border", checked: hideBorder, set: setHideBorder },
-                    { label: "Hide Title", checked: hideTitle, set: setHideTitle }].map((t) => (
+                  {[
+                    {
+                      label: "Hide Border",
+                      checked: hideBorder,
+                      set: setHideBorder,
+                    },
+                    {
+                      label: "Hide Title",
+                      checked: hideTitle,
+                      set: setHideTitle,
+                    },
+                  ].map((t) => (
                     <label key={t.label} className="toggle-label">
                       <input
                         type="checkbox"
@@ -559,8 +655,21 @@ export default function CardPreview() {
                     onChange={(e) => setMiniMetric(e.target.value)}
                     className="input-field"
                   >
-                    {["stars","commits","prs","issues","hours","streak","week","followers","repos","contributions"].map((m) => (
-                      <option key={m} value={m}>{m}</option>
+                    {[
+                      "stars",
+                      "commits",
+                      "prs",
+                      "issues",
+                      "hours",
+                      "streak",
+                      "week",
+                      "followers",
+                      "repos",
+                      "contributions",
+                    ].map((m) => (
+                      <option key={m} value={m}>
+                        {m}
+                      </option>
                     ))}
                   </select>
                 </div>
@@ -575,7 +684,9 @@ export default function CardPreview() {
                   />
                 </div>
                 <div>
-                  <label className="label-text">Accent Colour (hex, no #)</label>
+                  <label className="label-text">
+                    Accent Colour (hex, no #)
+                  </label>
                   <input
                     type="text"
                     value={miniColor}
@@ -650,8 +761,7 @@ export default function CardPreview() {
                     />
                   </div>
                   <div>
-                    <label className="label-text">Fill Colour (hex)
-                    </label>
+                    <label className="label-text">Fill Colour (hex)</label>
                     <input
                       type="text"
                       value={sparkFillColor}
@@ -720,7 +830,10 @@ export default function CardPreview() {
         </div>
 
         {/* ─── Embed Code ─── */}
-        <div className="grid gap-4 sm:grid-cols-3 animate-slide-up" style={{ animationDelay: "160ms" }}>
+        <div
+          className="grid gap-4 sm:grid-cols-3 animate-slide-up"
+          style={{ animationDelay: "160ms" }}
+        >
           {[
             { label: "Link", code: embedUrl, id: "link" },
             { label: "Markdown", code: markdownCode, id: "md" },
@@ -737,7 +850,9 @@ export default function CardPreview() {
                   className="copy-btn"
                 >
                   {copiedField === block.id ? (
-                    <span className="text-[#3fb950] transition-colors duration-200">Copied!</span>
+                    <span className="text-[#3fb950] transition-colors duration-200">
+                      Copied!
+                    </span>
                   ) : (
                     "Copy"
                   )}

--- a/src/components/CardPreview.tsx
+++ b/src/components/CardPreview.tsx
@@ -115,7 +115,7 @@ export default function CardPreview() {
     | "grid"
     | "donut"
     | "donut_vertical"
-    | "hidden"
+    | "compact"
   >("bar");
   const [maxLangs, setMaxLangs] = useState(8);
 
@@ -567,7 +567,7 @@ export default function CardPreview() {
                       [
                         "donut",
                         "donut_vertical",
-                        "hidden",
+                        "compact",
                         "bar",
                         "stacked",
                         "horizontal_list",

--- a/src/components/CardPreview.tsx
+++ b/src/components/CardPreview.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { themes } from "@/lib/themes";
 import { renderBadge } from "@/app/api/badge/badge-svg";
+import { LANG_CHART_LAYOUTS, LangChartLayout } from "@/lib/types";
 
 const STAT_OPTIONS = [
   { key: "stars", label: "Stars" },
@@ -83,6 +84,14 @@ function BadgeStylePicker({
   );
 }
 
+//Helper function to conver the layout key (snake_case) into Title case.
+function formatLayoutLabel(layout: string): string {
+  return layout
+    .split("_")
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 export default function CardPreview() {
   const [embedType, setEmbedType] = useState<EmbedType>("card");
   const [username, setUsername] = useState("octocat");
@@ -107,16 +116,7 @@ export default function CardPreview() {
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   // Languages options
-  const [langLayout, setLangLayout] = useState<
-    | "bar"
-    | "stacked"
-    | "horizontal_list"
-    | "vertical_list"
-    | "grid"
-    | "donut"
-    | "donut_vertical"
-    | "compact"
-  >("bar");
+  const [langLayout, setLangLayout] = useState<LangChartLayout>("bar");
   const [maxLangs, setMaxLangs] = useState(8);
 
   // Mini badge options
@@ -563,18 +563,7 @@ export default function CardPreview() {
                   <label className="label-text">Layout</label>
                   <div className="mt-2 flex flex-wrap gap-1.5 rounded-xl border border-[#30363d] bg-[#161b22] p-1.5">
                     {" "}
-                    {(
-                      [
-                        "donut",
-                        "donut_vertical",
-                        "compact",
-                        "bar",
-                        "stacked",
-                        "horizontal_list",
-                        "vertical_list",
-                        "grid",
-                      ] as const
-                    ).map((opt) => (
+                    {LANG_CHART_LAYOUTS.map((opt) => (
                       <button
                         key={opt}
                         onClick={() => setLangLayout(opt)}
@@ -584,21 +573,7 @@ export default function CardPreview() {
                             : "text-[#8b949e] hover:text-[#c9d1d9] border border-transparent"
                         }`}
                       >
-                        {opt === "bar"
-                          ? "Bar"
-                          : opt === "stacked"
-                            ? "Stacked"
-                            : opt === "horizontal_list"
-                              ? "Horizontal List"
-                              : opt === "vertical_list"
-                                ? "Vertical List"
-                                : opt === "grid"
-                                  ? "Grid"
-                                  : opt === "donut"
-                                    ? "Donut"
-                                    : opt === "donut_vertical"
-                                      ? "Donut Vertical"
-                                      : "Compact"}
+                        {formatLayoutLabel(opt)}
                       </button>
                     ))}
                   </div>

--- a/src/components/CardPreview.tsx
+++ b/src/components/CardPreview.tsx
@@ -561,7 +561,7 @@ export default function CardPreview() {
               <div className="space-y-4 rounded-xl border border-[#30363d]/60 bg-[#0d1117] px-4 py-4">
                 <div>
                   <label className="label-text">Layout</label>
-                  <div className="mt-2 grid grid-cols-5 rounded-xl border border-[#30363d] bg-[#161b22] p-[3px]">
+                  <div className="mt-2 flex flex-wrap gap-1.5 rounded-xl border border-[#30363d] bg-[#161b22] p-1.5">
                     {" "}
                     {(
                       [
@@ -578,10 +578,10 @@ export default function CardPreview() {
                       <button
                         key={opt}
                         onClick={() => setLangLayout(opt)}
-                        className={`px-4 py-1.5 rounded-[9px] text-xs font-semibold tracking-wide transition-all duration-200 ease-out ${
+                        className={`px-3 py-1.5 rounded-[9px] text-xs font-semibold tracking-wide whitespace-nowrap transition-all duration-200 ease-out ${
                           langLayout === opt
                             ? "bg-[#21262d] text-white shadow-sm border border-[#30363d]"
-                            : "text-[#8b949e] hover:text-[#c9d1d9]"
+                            : "text-[#8b949e] hover:text-[#c9d1d9] border border-transparent"
                         }`}
                       >
                         {opt === "bar"

--- a/src/lib/svg.ts
+++ b/src/lib/svg.ts
@@ -582,7 +582,7 @@ export function renderLanguageChart(
     );
   }
 
-  if (options.layout === "hidden") {
+  if (options.layout === "compact") {
     return renderCompact(topLangs, totalSize, theme, options);
   }
 

--- a/src/lib/svg.ts
+++ b/src/lib/svg.ts
@@ -1,4 +1,11 @@
-import { GitHubStats, ThemeConfig, CardOptions, LanguageStat, LangChartOptions, ContributionDay } from "./types";
+import {
+  GitHubStats,
+  ThemeConfig,
+  CardOptions,
+  LanguageStat,
+  LangChartOptions,
+  ContributionDay,
+} from "./types";
 import { escapeXml, formatNumber } from "./sanitize";
 
 // Octicon-style SVG paths (16x16 viewBox)
@@ -23,8 +30,7 @@ const ICONS: Record<string, string> = {
     "M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm.5 4.75v3.44l2.78 1.61a.75.75 0 1 1-.75 1.3l-3.16-1.83A.75.75 0 0 1 7 8.69V4.75a.75.75 0 0 1 1.5 0z",
   trophy:
     "M4.25 1a.25.25 0 0 0-.25.25v1h-1A1.75 1.75 0 0 0 1.25 4v1c0 .966.784 1.75 1.75 1.75h.25v.457a4.002 4.002 0 0 0 2.5 3.693V12h-1a.75.75 0 0 0 0 1.5h6.5a.75.75 0 0 0 0-1.5h-1v-1.1a4.002 4.002 0 0 0 2.5-3.693V6.75h.25c.966 0 1.75-.784 1.75-1.75V4c0-.966-.784-1.75-1.75-1.75h-1v-1A.25.25 0 0 0 11.75 1zM3 4.25h1v2.5H3.25a.25.25 0 0 1-.25-.25V4.25zm10 0v2.25a.25.25 0 0 1-.25.25H12v-2.5z",
-  day:
-    "M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zM1.5 8a6.5 6.5 0 1 1 13 0 6.5 6.5 0 0 1-13 0zm9.78-2.22-4.03 4.03-1.97-1.97a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.06 0l4.56-4.56a.75.75 0 0 0-1.06-1.06z",
+  day: "M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zM1.5 8a6.5 6.5 0 1 1 13 0 6.5 6.5 0 0 1-13 0zm9.78-2.22-4.03 4.03-1.97-1.97a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.06 0l4.56-4.56a.75.75 0 0 0-1.06-1.06z",
 };
 
 interface StatItem {
@@ -35,7 +41,10 @@ interface StatItem {
   trend?: { direction: "up" | "down" | "neutral"; text: string };
 }
 
-function formatTrend(pct: number): { direction: "up" | "down" | "neutral"; text: string } {
+function formatTrend(pct: number): {
+  direction: "up" | "down" | "neutral";
+  text: string;
+} {
   if (pct > 0) return { direction: "up", text: `+${pct}%` };
   if (pct < 0) return { direction: "down", text: `${pct}%` };
   return { direction: "neutral", text: "0%" };
@@ -45,13 +54,17 @@ function charWidth(ch: string, fontSize: number): number {
   const c = ch.toLowerCase();
   if ("ijlt!:;|".includes(c)) return fontSize * 0.27;
   if ("frskce".includes(c)) return fontSize * 0.42;
-  if ("adgnoquvxyzsbhkp".includes(c)) return fontSize * 0.50;
+  if ("adgnoquvxyzsbhkp".includes(c)) return fontSize * 0.5;
   if ("mwW".includes(c)) return fontSize * 0.58;
   if ("MQ@".includes(c)) return fontSize * 0.69;
-  return fontSize * 0.50;
+  return fontSize * 0.5;
 }
 
-function truncateToWidth(text: string, maxWidth: number, fontSize: number): string {
+function truncateToWidth(
+  text: string,
+  maxWidth: number,
+  fontSize: number,
+): string {
   let width = 0;
   let lastFit = 0;
   for (let i = 0; i < text.length; i++) {
@@ -90,7 +103,14 @@ function getVisibleStats(
   order?: string[],
 ): StatItem[] {
   const year = new Date().getFullYear();
-  const all: { key: string; label: string; short: string; value: string; icon: string; trend?: StatItem["trend"] }[] = [
+  const all: {
+    key: string;
+    label: string;
+    short: string;
+    value: string;
+    icon: string;
+    trend?: StatItem["trend"];
+  }[] = [
     {
       key: "stars",
       label: "Total Stars Earned",
@@ -206,7 +226,13 @@ function getVisibleStats(
     });
   }
 
-  return filtered.map(({ label, short, value, icon, trend }) => ({ label, short, value, icon, trend }));
+  return filtered.map(({ label, short, value, icon, trend }) => ({
+    label,
+    short,
+    value,
+    icon,
+    trend,
+  }));
 }
 
 function renderActivityRing(
@@ -234,9 +260,19 @@ function renderActivityRing(
 }
 
 const EMOJIS: Record<string, string> = {
-  star: "⭐", commit: "💻", pr: "🔀", issue: "🐛",
-  fire: "🔥", calendar: "📅", trend: "📈", clock: "⏱",
-  day: "📆", trophy: "🏆", graph: "📊", repo: "📁", people: "👥",
+  star: "⭐",
+  commit: "💻",
+  pr: "🔀",
+  issue: "🐛",
+  fire: "🔥",
+  calendar: "📅",
+  trend: "📈",
+  clock: "⏱",
+  day: "📆",
+  trophy: "🏆",
+  graph: "📊",
+  repo: "📁",
+  people: "👥",
 };
 
 function renderCompactCard(
@@ -247,7 +283,10 @@ function renderCompactCard(
   const count = options.compact_count;
   // 4 stats → 2 cols; 3 or 6 → 3 cols
   const COLS = count === 4 ? 2 : 3;
-  const visible = getVisibleStats(stats, options.hide, options.order).slice(0, count);
+  const visible = getVisibleStats(stats, options.hide, options.order).slice(
+    0,
+    count,
+  );
   const useEmoji = options.show_emoji;
 
   const W = 495;
@@ -262,7 +301,8 @@ function renderCompactCard(
   const PAD_BOT = 14;
   const numRows = Math.ceil(visible.length / COLS);
   const statsStartY = PAD_TOP + TITLE_H;
-  const cardHeight = statsStartY + numRows * CELL_H + (numRows - 1) * ROW_GAP + PAD_BOT;
+  const cardHeight =
+    statsStartY + numRows * CELL_H + (numRows - 1) * ROW_GAP + PAD_BOT;
   const rx = options.border_radius;
 
   const title = options.custom_title
@@ -370,7 +410,9 @@ export function renderCard(
 
   const statsStartY = PAD_TOP + TITLE_H + GAP;
   const statsHeight = visible.length * ROW_H;
-  const minHeight = showRing ? RING_AREA + PAD_TOP + TITLE_H + GAP + PAD_BOT : 0;
+  const minHeight = showRing
+    ? RING_AREA + PAD_TOP + TITLE_H + GAP + PAD_BOT
+    : 0;
   const cardHeight = Math.max(statsStartY + statsHeight + PAD_BOT, minHeight);
   const rx = options.border_radius;
 
@@ -382,7 +424,9 @@ export function renderCard(
     ? ""
     : `<text x="${PAD_X}" y="${PAD_TOP + TITLE_FS}" class="title">${title}</text>`;
 
-  const statAreaWidth = showRing ? CARD_WIDTH - PAD_X - RING_AREA - 10 : CARD_WIDTH - PAD_X;
+  const statAreaWidth = showRing
+    ? CARD_WIDTH - PAD_X - RING_AREA - 10
+    : CARD_WIDTH - PAD_X;
 
   const rows = visible
     .map((stat, i) => {
@@ -399,14 +443,19 @@ export function renderCard(
       let trendSvg = "";
       if (stat.trend) {
         const arrowColor =
-          stat.trend.direction === "up" ? "#3fb950" : stat.trend.direction === "down" ? "#f85149" : theme.text;
+          stat.trend.direction === "up"
+            ? "#3fb950"
+            : stat.trend.direction === "down"
+              ? "#f85149"
+              : theme.text;
         const arrowPath =
           stat.trend.direction === "up"
             ? "M 0 6 L 4 0 L 8 6 L 5 6 L 5 10 L 3 10 L 3 6 Z"
             : stat.trend.direction === "down"
               ? "M 0 4 L 4 10 L 8 4 L 5 4 L 5 0 L 3 0 L 3 4 Z"
               : "M 0 4 L 8 4 L 8 6 L 0 6 Z";
-        const labelWidth = stat.value.length * CHAR_W + (showIcons ? TEXT_ICON_PAD : 0);
+        const labelWidth =
+          stat.value.length * CHAR_W + (showIcons ? TEXT_ICON_PAD : 0);
         const arrowX = textX + labelWidth + 60;
         trendSvg = `<g transform="translate(${arrowX}, ${y + 2})">
           <path d="${arrowPath}" fill="${arrowColor}"/>
@@ -428,9 +477,17 @@ export function renderCard(
     : ` stroke="${theme.border}" stroke-width="1"`;
 
   const ringCx = CARD_WIDTH - PAD_X - RING_R - 5;
-  const ringCy = statsStartY + (statsHeight / 2);
+  const ringCy = statsStartY + statsHeight / 2;
   const ringSvg = showRing
-    ? renderActivityRing(ringCx, ringCy, RING_R, stats.activityLevel, stats.grade, theme, RING_STROKE)
+    ? renderActivityRing(
+        ringCx,
+        ringCy,
+        RING_R,
+        stats.activityLevel,
+        stats.grade,
+        theme,
+        RING_STROKE,
+      )
     : "";
 
   return `<svg width="${CARD_WIDTH}" height="${cardHeight}" viewBox="0 0 ${CARD_WIDTH} ${cardHeight}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="${title}">
@@ -483,6 +540,7 @@ export function renderLanguageChart(
 ): string {
   const maxLangs = Math.min(options.max_langs, 12);
   const topLangs = languages.slice(0, maxLangs);
+  console.log("DEBUG layout value:", JSON.stringify(options.layout));
 
   if (topLangs.length === 0) {
     return renderErrorCard("No language data available for this user.", theme);
@@ -499,11 +557,33 @@ export function renderLanguageChart(
   }
 
   if (options.layout === "horizontal_list") {
-    return renderHorizontalListLanguageChart(topLangs, totalSize, theme, options);
+    return renderHorizontalListLanguageChart(
+      topLangs,
+      totalSize,
+      theme,
+      options,
+    );
   }
 
   if (options.layout === "stacked") {
     return renderStackedLanguageChart(topLangs, totalSize, theme, options);
+  }
+
+  if (options.layout === "donut") {
+    return renderDonutLanguageChart(topLangs, totalSize, theme, options);
+  }
+
+  if (options.layout === "donut_vertical") {
+    return renderDonutVerticalLanguageChart(
+      topLangs,
+      totalSize,
+      theme,
+      options,
+    );
+  }
+
+  if (options.layout === "hidden") {
+    return renderCompact(topLangs, totalSize, theme, options);
   }
 
   const W = 495;
@@ -548,7 +628,9 @@ export function renderLanguageChart(
     ? ""
     : `<text x="${PAD}" y="${TITLE_H - 4}" class="lc-title">${escapeXml(options.custom_title ?? "Top Languages")}</text>`;
 
-  const border = options.hide_border ? "" : ` stroke="${theme.border}" stroke-width="1"`;
+  const border = options.hide_border
+    ? ""
+    : ` stroke="${theme.border}" stroke-width="1"`;
 
   return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Top Languages">
   <title>${escapeXml(options.custom_title ?? "Top Languages")}</title>
@@ -601,9 +683,10 @@ function renderStackedLanguageChart(
   let bx = PAD;
   const barSegments = segments.map(({ lang, pct, w }) => {
     const rect = `<rect x="${bx}" y="${BAR_Y}" width="${w}" height="${BAR_H}" fill="${lang.color ?? "#586069"}"/>`;
-    const label = w >= 36
-      ? `<text x="${bx + w / 2}" y="${BAR_Y + BAR_H / 2 + 4}" text-anchor="middle" font="600 10px 'Segoe UI', Ubuntu, sans-serif" fill="#fff" opacity="0.9">${escapeXml(lang.name)}</text>`
-      : "";
+    const label =
+      w >= 36
+        ? `<text x="${bx + w / 2}" y="${BAR_Y + BAR_H / 2 + 4}" text-anchor="middle" font="600 10px 'Segoe UI', Ubuntu, sans-serif" fill="#fff" opacity="0.9">${escapeXml(lang.name)}</text>`
+        : "";
     bx += w;
     return rect + label;
   });
@@ -615,7 +698,8 @@ function renderStackedLanguageChart(
     const ly = NAMES_TOP + row * ROW_H;
     const pct = totalSize > 0 ? (lang.size / totalSize) * 100 : 0;
     const pctText = `${pct.toFixed(1)}%`;
-    const name = lang.name.length > 16 ? `${lang.name.slice(0, 15)}…` : lang.name;
+    const name =
+      lang.name.length > 16 ? `${lang.name.slice(0, 15)}…` : lang.name;
     return `<circle cx="${lx + 6}" cy="${ly + 5}" r="4" fill="${lang.color ?? "#586069"}"/>
   <text x="${lx + 14}" y="${ly + 9}" class="lc-name">${escapeXml(name)}</text>
   <text x="${lx + COL_W - 2}" y="${ly + 9}" class="lc-pct" text-anchor="end">${pctText}</text>`;
@@ -625,7 +709,9 @@ function renderStackedLanguageChart(
     ? ""
     : `<text x="${PAD}" y="${TITLE_H - 4}" class="lc-title">${escapeXml(options.custom_title ?? "Top Languages")}</text>`;
 
-  const border = options.hide_border ? "" : ` stroke="${theme.border}" stroke-width="1"`;
+  const border = options.hide_border
+    ? ""
+    : ` stroke="${theme.border}" stroke-width="1"`;
 
   return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Top Languages (stacked)">
   <title>${escapeXml(options.custom_title ?? "Top Languages")}</title>
@@ -652,7 +738,8 @@ function renderBaseCard(
   borderOpacity?: number,
 ): string {
   const stroke = borderColor ?? theme.border;
-  const opacity = borderOpacity !== undefined ? ` stroke-opacity="${borderOpacity}"` : "";
+  const opacity =
+    borderOpacity !== undefined ? ` stroke-opacity="${borderOpacity}"` : "";
   return `<rect x="${x}" y="${y}" width="${w}" height="${h}" rx="${rx}" ry="${rx}" fill="${theme.bg}" stroke="${stroke}" stroke-width="1"${opacity}/>`;
 }
 
@@ -747,7 +834,17 @@ function renderGridLanguageChart(
     const cx = PAD + col * (CARD_W + GAP);
     const cy = GRID_TOP + row * (CARD_H + GAP);
     const pct = formatLangPct(lang.size, filteredTotal);
-    const cardContent = renderLanguageCard(cx, cy, CARD_W, CARD_H, lang, pct, rx, theme, numLangs === 1);
+    const cardContent = renderLanguageCard(
+      cx,
+      cy,
+      CARD_W,
+      CARD_H,
+      lang,
+      pct,
+      rx,
+      theme,
+      numLangs === 1,
+    );
     return `<g clip-path="url(#gl-card-${i})">${cardContent}</g>`;
   });
 
@@ -755,7 +852,9 @@ function renderGridLanguageChart(
     ? ""
     : `<text x="${PAD}" y="${TITLE_H - 4}" class="gl-title">${escapeXml(options.custom_title ?? "Top Languages")}</text>`;
 
-  const border = options.hide_border ? "" : ` stroke="${theme.border}" stroke-width="1"`;
+  const border = options.hide_border
+    ? ""
+    : ` stroke="${theme.border}" stroke-width="1"`;
 
   return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Top Languages (grid)">
   <title>${escapeXml(options.custom_title ?? "Top Languages")}</title>
@@ -802,16 +901,24 @@ function renderHorizontalListLanguageChart(
   const items = languages.map((lang) => {
     const pct = formatLangPct(lang.size, totalSize);
     const displayName = truncateToWidth(lang.name, BAR_W - 60, 11);
-    const itemTextWidth = CIRCLE_R * 2 + CIRCLE_GAP + estimateTextWidth(displayName, 11) + 14 + estimateTextWidth(pct, 11);
+    const itemTextWidth =
+      CIRCLE_R * 2 +
+      CIRCLE_GAP +
+      estimateTextWidth(displayName, 11) +
+      14 +
+      estimateTextWidth(pct, 11);
     return { lang: { ...lang, displayName }, pct, itemTextWidth };
   });
 
-  const rows: (typeof items[0])[][] = [];
-  let currentRow: typeof items[0][] = [];
+  const rows: (typeof items)[0][][] = [];
+  let currentRow: (typeof items)[0][] = [];
   let currentWidth = 0;
 
   for (const item of items) {
-    const totalRowWidth = currentWidth + item.itemTextWidth + (currentRow.length > 0 ? ITEM_GAP : 0);
+    const totalRowWidth =
+      currentWidth +
+      item.itemTextWidth +
+      (currentRow.length > 0 ? ITEM_GAP : 0);
     if (currentRow.length > 0 && totalRowWidth > BAR_W) {
       rows.push(currentRow);
       currentRow = [item];
@@ -827,28 +934,35 @@ function renderHorizontalListLanguageChart(
   const ITEMS_TOP = BAR_Y + BAR_H + 18;
   const H = ITEMS_TOP + numRows * ROW_H + 16;
 
-  const itemSvgs = rows.map((row, rowIdx) => {
-    const y = ITEMS_TOP + rowIdx * ROW_H;
-    let x = PAD;
-    return row.map((item, colIdx) => {
-      const circleX = x + CIRCLE_R;
-      const textX = x + CIRCLE_R * 2 + CIRCLE_GAP;
-      const pctX = textX + estimateTextWidth(item.lang.displayName, 11) + 14;
+  const itemSvgs = rows
+    .map((row, rowIdx) => {
+      const y = ITEMS_TOP + rowIdx * ROW_H;
+      let x = PAD;
+      return row
+        .map((item, colIdx) => {
+          const circleX = x + CIRCLE_R;
+          const textX = x + CIRCLE_R * 2 + CIRCLE_GAP;
+          const pctX =
+            textX + estimateTextWidth(item.lang.displayName, 11) + 14;
 
-      const svg = `<circle cx="${circleX}" cy="${y + 5}" r="${CIRCLE_R}" fill="${item.lang.color ?? "#586069"}"/>
+          const svg = `<circle cx="${circleX}" cy="${y + 5}" r="${CIRCLE_R}" fill="${item.lang.color ?? "#586069"}"/>
     <text x="${textX}" y="${y + 9}" class="lc-name">${escapeXml(item.lang.displayName)}</text>
     <text x="${pctX}" y="${y + 9}" class="lc-pct">${escapeXml(item.pct)}</text>`;
 
-      x += item.itemTextWidth + (colIdx < row.length - 1 ? ITEM_GAP : 0);
-      return svg;
-    }).join("\n  ");
-  }).join("\n");
+          x += item.itemTextWidth + (colIdx < row.length - 1 ? ITEM_GAP : 0);
+          return svg;
+        })
+        .join("\n  ");
+    })
+    .join("\n");
 
   const titleSvg = options.hide_title
     ? ""
     : `<text x="${PAD}" y="${TITLE_H - 4}" class="lc-title">${escapeXml(options.custom_title ?? "Top Languages")}</text>`;
 
-  const border = options.hide_border ? "" : ` stroke="${theme.border}" stroke-width="1"`;
+  const border = options.hide_border
+    ? ""
+    : ` stroke="${theme.border}" stroke-width="1"`;
 
   return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Top Languages (horizontal list)">
   <title>${escapeXml(options.custom_title ?? "Top Languages")}</title>
@@ -897,9 +1011,10 @@ function renderVerticalListLanguageChart(
     const pct = formatLangPct(lang.size, totalSize);
     const name = truncateToWidth(lang.name, W - PAD * 2 - 60, 13);
 
-    const divider = i < languages.length - 1
-      ? `<line x1="${PAD}" y1="${y + ROW_H}" x2="${W - PAD}" y2="${y + ROW_H}" stroke="${theme.border}" stroke-width="1" opacity="0.2"/>`
-      : "";
+    const divider =
+      i < languages.length - 1
+        ? `<line x1="${PAD}" y1="${y + ROW_H}" x2="${W - PAD}" y2="${y + ROW_H}" stroke="${theme.border}" stroke-width="1" opacity="0.2"/>`
+        : "";
 
     return `${divider}
     <circle cx="${PAD + CIRCLE_R}" cy="${y + ROW_H / 2}" r="${CIRCLE_R}" fill="${lang.color ?? "#586069"}"/>
@@ -911,7 +1026,9 @@ function renderVerticalListLanguageChart(
     ? ""
     : `<text x="${PAD}" y="${TITLE_H - 4}" class="lc-title">${escapeXml(options.custom_title ?? "Top Languages")}</text>`;
 
-  const border = options.hide_border ? "" : ` stroke="${theme.border}" stroke-width="1"`;
+  const border = options.hide_border
+    ? ""
+    : ` stroke="${theme.border}" stroke-width="1"`;
 
   return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Top Languages (vertical list)">
   <title>${escapeXml(options.custom_title ?? "Top Languages")}</title>
@@ -925,6 +1042,305 @@ function renderVerticalListLanguageChart(
   ${titleSvg}
   <g clip-path="url(#vl-clip)">${barSegments.join("")}</g>
   ${langRows.join("\n")}
+</svg>`;
+}
+
+// Contributed by ittzspsv
+
+function renderDonutVerticalLanguageChart(
+  languages: LanguageStat[],
+  totalSize: number,
+  theme: ThemeConfig,
+  options: LangChartOptions,
+): string {
+  const W = 300;
+  const PAD = 22;
+  const TITLE_H = options.hide_title ? 0 : 28;
+  const RADIUS = 72;
+  const RING = 0.62; // donut inner radius ratio — modern look, avoids "pie chart from Excel 2003"
+  const COLS = 1;
+  const ROW_H = 22;
+  const GAP_CIRCLE_LEGEND = 24; // vertical gap between donut and legend block instead of horizontal
+
+  const numRows = Math.ceil(Math.min(languages.length, 12) / COLS);
+  const legendH = numRows * ROW_H;
+
+  const CX = W / 2;
+  const CY = TITLE_H + 20 + RADIUS; // donut sits on top, centered horizontally
+
+  const LEGEND_X = PAD;
+  const LEGEND_W = W - PAD * 2;
+  const COL_W = Math.floor(LEGEND_W / COLS);
+  const legendTop = CY + RADIUS + GAP_CIRCLE_LEGEND;
+
+  const H = legendTop + legendH + 20;
+  const rx = options.border_radius;
+
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+
+  let cumulativeAngle = -90;
+  const slices = languages.map((lang) => {
+    const pct = totalSize > 0 ? lang.size / totalSize : 0;
+    const angle = pct * 360;
+    const startAngle = cumulativeAngle;
+    const endAngle = cumulativeAngle + angle;
+    cumulativeAngle = endAngle;
+
+    const innerR = RADIUS * RING;
+
+    if (angle >= 359.999) {
+      return `<circle cx="${CX}" cy="${CY}" r="${RADIUS}" fill="none" stroke="${lang.color ?? "#586069"}" stroke-width="${RADIUS - innerR}"/>`;
+    }
+
+    // Donut wedge: outer arc + inner arc, connected — reads cleaner than filled pie slices, especially for many small langs
+    const ox1 = CX + RADIUS * Math.cos(toRad(startAngle));
+    const oy1 = CY + RADIUS * Math.sin(toRad(startAngle));
+    const ox2 = CX + RADIUS * Math.cos(toRad(endAngle));
+    const oy2 = CY + RADIUS * Math.sin(toRad(endAngle));
+    const ix1 = CX + innerR * Math.cos(toRad(endAngle));
+    const iy1 = CY + innerR * Math.sin(toRad(endAngle));
+    const ix2 = CX + innerR * Math.cos(toRad(startAngle));
+    const iy2 = CY + innerR * Math.sin(toRad(startAngle));
+    const largeArc = angle > 180 ? 1 : 0;
+
+    const path = [
+      `M ${ox1.toFixed(2)} ${oy1.toFixed(2)}`,
+      `A ${RADIUS} ${RADIUS} 0 ${largeArc} 1 ${ox2.toFixed(2)} ${oy2.toFixed(2)}`,
+      `L ${ix1.toFixed(2)} ${iy1.toFixed(2)}`,
+      `A ${innerR} ${innerR} 0 ${largeArc} 0 ${ix2.toFixed(2)} ${iy2.toFixed(2)}`,
+      `Z`,
+    ].join(" ");
+
+    return `<path d="${path}" fill="${lang.color ?? "#586069"}" stroke="${theme.bg}" stroke-width="1.5"/>`;
+  });
+
+  // Center label: top language + total, since donut leaves a natural focal point
+  const topLang = languages[0];
+  const topPct =
+    topLang && totalSize > 0
+      ? ((topLang.size / totalSize) * 100).toFixed(0)
+      : "0";
+  const centerLabel = topLang
+    ? `<text x="${CX}" y="${CY - 4}" text-anchor="middle" class="lc-center-pct">${topPct}%</text>
+  <text x="${CX}" y="${CY + 12}" text-anchor="middle" class="lc-center-name">${escapeXml(topLang.name.length > 10 ? topLang.name.slice(0, 9) + "…" : topLang.name)}</text>`
+    : "";
+
+  const legend = languages.slice(0, 12).map((lang, i) => {
+    const col = i % COLS;
+    const row = Math.floor(i / COLS);
+    const lx = LEGEND_X + col * COL_W;
+    const ly = legendTop + row * ROW_H;
+    const pct = totalSize > 0 ? (lang.size / totalSize) * 100 : 0;
+    const maxNameLen = 16; // single column has more horizontal room than the 2-col layout
+    const name =
+      lang.name.length > maxNameLen
+        ? `${lang.name.slice(0, maxNameLen - 1)}…`
+        : lang.name;
+    return `<circle cx="${lx + 6}" cy="${ly + 10}" r="4" fill="${lang.color ?? "#586069"}"/>
+  <text x="${lx + 15}" y="${ly + 14}" class="lc-name">${escapeXml(name)}</text>
+  <text x="${lx + COL_W}" y="${ly + 14}" class="lc-pct" text-anchor="end">${pct.toFixed(1)}%</text>`;
+  });
+
+  const titleSvg = options.hide_title
+    ? ""
+    : `<text x="${PAD}" y="${TITLE_H - 4}" class="lc-title">${escapeXml(options.custom_title ?? "Top Languages")}</text>`;
+
+  const border = options.hide_border
+    ? ""
+    : ` stroke="${theme.border}" stroke-width="1"`;
+
+  return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Top Languages (pie)">
+  <title>${escapeXml(options.custom_title ?? "Top Languages")}</title>
+  <style>
+    .lc-title       { font: 600 14px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.title}; }
+    .lc-name        { font: 400 11px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.text}; }
+    .lc-pct         { font: 600 11px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.text}; opacity: 0.7; }
+    .lc-center-pct  { font: 700 18px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.title}; }
+    .lc-center-name { font: 400 10px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.text}; opacity: 0.7; }
+  </style>
+  <rect x="0.5" y="0.5" rx="${rx}" ry="${rx}" width="${W - 1}" height="${H - 1}" fill="${theme.bg}"${border}/>
+  ${titleSvg}
+  <g>${slices.join("")}</g>
+  ${centerLabel}
+  ${legend.join("\n  ")}
+</svg>`;
+}
+
+function renderDonutLanguageChart(
+  languages: LanguageStat[],
+  totalSize: number,
+  theme: ThemeConfig,
+  options: LangChartOptions,
+): string {
+  const W = 495;
+  const PAD = 22;
+  const TITLE_H = options.hide_title ? 0 : 28;
+  const RADIUS = 72;
+  const RING = 0.62; // donut inner radius ratio — modern look, avoids "pie chart from Excel 2003"
+  const COLS = 2;
+  const ROW_H = 22;
+  const GAP_CIRCLE_LEGEND = 40;
+
+  const numRows = Math.ceil(Math.min(languages.length, 12) / COLS);
+  const legendH = numRows * ROW_H;
+  const contentH = Math.max(RADIUS * 2, legendH);
+
+  const CX = PAD + RADIUS;
+  const CY = TITLE_H + 20 + contentH / 2; // pie vertically centered against whichever block (circle or legend) is taller
+
+  const LEGEND_X = CX + RADIUS + GAP_CIRCLE_LEGEND;
+  const LEGEND_W = W - LEGEND_X - PAD;
+  const COL_W = Math.floor(LEGEND_W / COLS);
+  const legendTop = CY - legendH / 2;
+
+  const H = TITLE_H + 20 + contentH + 20;
+  const rx = options.border_radius;
+
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+
+  let cumulativeAngle = -90;
+  const slices = languages.map((lang) => {
+    const pct = totalSize > 0 ? lang.size / totalSize : 0;
+    const angle = pct * 360;
+    const startAngle = cumulativeAngle;
+    const endAngle = cumulativeAngle + angle;
+    cumulativeAngle = endAngle;
+
+    const innerR = RADIUS * RING;
+
+    if (angle >= 359.999) {
+      return `<circle cx="${CX}" cy="${CY}" r="${RADIUS}" fill="none" stroke="${lang.color ?? "#586069"}" stroke-width="${RADIUS - innerR}"/>`;
+    }
+
+    // Donut wedge: outer arc + inner arc, connected — reads cleaner than filled pie slices, especially for many small langs
+    const ox1 = CX + RADIUS * Math.cos(toRad(startAngle));
+    const oy1 = CY + RADIUS * Math.sin(toRad(startAngle));
+    const ox2 = CX + RADIUS * Math.cos(toRad(endAngle));
+    const oy2 = CY + RADIUS * Math.sin(toRad(endAngle));
+    const ix1 = CX + innerR * Math.cos(toRad(endAngle));
+    const iy1 = CY + innerR * Math.sin(toRad(endAngle));
+    const ix2 = CX + innerR * Math.cos(toRad(startAngle));
+    const iy2 = CY + innerR * Math.sin(toRad(startAngle));
+    const largeArc = angle > 180 ? 1 : 0;
+
+    const path = [
+      `M ${ox1.toFixed(2)} ${oy1.toFixed(2)}`,
+      `A ${RADIUS} ${RADIUS} 0 ${largeArc} 1 ${ox2.toFixed(2)} ${oy2.toFixed(2)}`,
+      `L ${ix1.toFixed(2)} ${iy1.toFixed(2)}`,
+      `A ${innerR} ${innerR} 0 ${largeArc} 0 ${ix2.toFixed(2)} ${iy2.toFixed(2)}`,
+      `Z`,
+    ].join(" ");
+
+    return `<path d="${path}" fill="${lang.color ?? "#586069"}" stroke="${theme.bg}" stroke-width="1.5"/>`;
+  });
+
+  // Center label: top language + total, since donut leaves a natural focal point
+  const topLang = languages[0];
+  const topPct =
+    topLang && totalSize > 0
+      ? ((topLang.size / totalSize) * 100).toFixed(0)
+      : "0";
+  const centerLabel = topLang
+    ? `<text x="${CX}" y="${CY - 4}" text-anchor="middle" class="lc-center-pct">${topPct}%</text>
+  <text x="${CX}" y="${CY + 12}" text-anchor="middle" class="lc-center-name">${escapeXml(topLang.name.length > 10 ? topLang.name.slice(0, 9) + "…" : topLang.name)}</text>`
+    : "";
+
+  const legend = languages.slice(0, 12).map((lang, i) => {
+    const col = i % COLS;
+    const row = Math.floor(i / COLS);
+    const lx = LEGEND_X + col * COL_W;
+    const ly = legendTop + row * ROW_H;
+    const pct = totalSize > 0 ? (lang.size / totalSize) * 100 : 0;
+    const maxNameLen = 12; // shortened slightly to guarantee room for fixed-width pct column
+    const name =
+      lang.name.length > maxNameLen
+        ? `${lang.name.slice(0, maxNameLen - 1)}…`
+        : lang.name;
+    return `<circle cx="${lx + 6}" cy="${ly + 10}" r="4" fill="${lang.color ?? "#586069"}"/>
+  <text x="${lx + 15}" y="${ly + 14}" class="lc-name">${escapeXml(name)}</text>
+  <text x="${lx + COL_W}" y="${ly + 14}" class="lc-pct" text-anchor="end">${pct.toFixed(1)}%</text>`;
+  });
+
+  const titleSvg = options.hide_title
+    ? ""
+    : `<text x="${PAD}" y="${TITLE_H - 4}" class="lc-title">${escapeXml(options.custom_title ?? "Top Languages")}</text>`;
+
+  const border = options.hide_border
+    ? ""
+    : ` stroke="${theme.border}" stroke-width="1"`;
+
+  return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Top Languages (pie)">
+  <title>${escapeXml(options.custom_title ?? "Top Languages")}</title>
+  <style>
+    .lc-title       { font: 600 14px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.title}; }
+    .lc-name        { font: 400 11px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.text}; }
+    .lc-pct         { font: 600 11px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.text}; opacity: 0.7; }
+    .lc-center-pct  { font: 700 18px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.title}; }
+    .lc-center-name { font: 400 10px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.text}; opacity: 0.7; }
+  </style>
+  <rect x="0.5" y="0.5" rx="${rx}" ry="${rx}" width="${W - 1}" height="${H - 1}" fill="${theme.bg}"${border}/>
+  ${titleSvg}
+  <g>${slices.join("")}</g>
+  ${centerLabel}
+  ${legend.join("\n  ")}
+</svg>`;
+}
+
+function renderCompact(
+  languages: LanguageStat[],
+  totalSize: number,
+  theme: ThemeConfig,
+  options: LangChartOptions,
+): string {
+  const W = 300;
+  const PAD = 22;
+  const TITLE_H = options.hide_title ? 0 : 34;
+  const COLS = 2;
+  const ROW_H = 28;
+  const DOT_R = 5;
+
+  const numRows = Math.ceil(Math.min(languages.length, 12) / COLS);
+  const legendH = numRows * ROW_H;
+
+  const LEGEND_X = PAD;
+  const LEGEND_W = W - PAD * 2;
+  const COL_W = Math.floor(LEGEND_W / COLS);
+  const legendTop = TITLE_H + 8;
+
+  const H = legendTop + legendH + 16;
+  const rx = options.border_radius;
+
+  const legend = languages.slice(0, 12).map((lang, i) => {
+    const col = i % COLS;
+    const row = Math.floor(i / COLS);
+    const lx = LEGEND_X + col * COL_W;
+    const ly = legendTop + row * ROW_H;
+    const maxNameLen = 14; // room for dot + name within a single legend column
+    const name =
+      lang.name.length > maxNameLen
+        ? `${lang.name.slice(0, maxNameLen - 1)}…`
+        : lang.name;
+    return `<circle cx="${lx + DOT_R}" cy="${ly + 10}" r="${DOT_R}" fill="${lang.color ?? "#586069"}"/>
+  <text x="${lx + DOT_R * 2 + 8}" y="${ly + 14}" class="lc-name">${escapeXml(name)}</text>`;
+  });
+
+  const titleSvg = options.hide_title
+    ? ""
+    : `<text x="${PAD}" y="${TITLE_H - 12}" class="lc-title">${escapeXml(options.custom_title ?? "Most Used Languages")}</text>`;
+
+  const border = options.hide_border
+    ? ""
+    : ` stroke="${theme.border}" stroke-width="1"`;
+
+  return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Most Used Languages">
+  <title>${escapeXml(options.custom_title ?? "Most Used Languages")}</title>
+  <style>
+    .lc-title { font: 600 15px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.title}; }
+    .lc-name  { font: 400 12px 'Segoe UI', Ubuntu, sans-serif; fill: ${theme.text}; }
+  </style>
+  <rect x="0.5" y="0.5" rx="${rx}" ry="${rx}" width="${W - 1}" height="${H - 1}" fill="${theme.bg}"${border}/>
+  ${titleSvg}
+  ${legend.join("\n  ")}
 </svg>`;
 }
 
@@ -966,7 +1382,10 @@ export function renderSparkline(
   const values = recent.map((d) => d.contributionCount);
   const maxVal = Math.max(...values, 1);
   const points = values.map((v, i) => {
-    const x = recent.length === 1 ? WIDTH / 2 : PAD_X + (i / (recent.length - 1)) * contentW;
+    const x =
+      recent.length === 1
+        ? WIDTH / 2
+        : PAD_X + (i / (recent.length - 1)) * contentW;
     const y = PAD_TOP + contentH - (v / maxVal) * contentH;
     return { x: Math.round(x * 10) / 10, y: Math.round(y * 10) / 10, v };
   });
@@ -986,7 +1405,9 @@ export function renderSparkline(
   const title = options.custom_title ?? `Last ${recent.length} days`; // fallback title
   const latestVal = values[values.length - 1];
 
-  const border = options.hide_border ? "" : ` stroke="${theme.border}" stroke-width="1"`;
+  const border = options.hide_border
+    ? ""
+    : ` stroke="${theme.border}" stroke-width="1"`;
 
   return `<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Contributions sparkline (latest ${latestVal})">
   <title>${escapeXml(title)}</title>
@@ -1002,4 +1423,3 @@ export function renderSparkline(
   <text x="${WIDTH - PAD_X}" y="${TITLE_Y}" class="sl-value" text-anchor="end">Today: ${latestVal}</text>
 </svg>`;
 }
-

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -65,7 +65,15 @@ export interface LangChartOptions {
   custom_title?: string;
   border_radius: number;
   max_langs: number; // max languages to show (default 8)
-  layout: "donut" | "bar" | "stacked" | "horizontal_list" | "vertical_list" | "grid"; // chart style
+  layout:
+    | "donut"
+    | "donut_vertical"
+    | "hidden"
+    | "bar"
+    | "stacked"
+    | "horizontal_list"
+    | "vertical_list"
+    | "grid"; // chart style
 }
 
 export type StatKey =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,7 +68,7 @@ export interface LangChartOptions {
   layout:
     | "donut"
     | "donut_vertical"
-    | "hidden"
+    | "compact"
     | "bar"
     | "stacked"
     | "horizontal_list"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,21 +59,27 @@ export interface CardOptions {
   order?: string[]; // custom stat display order
 }
 
+//This is the single source of truth.  Add new Language Options here.
+export const LANG_CHART_LAYOUTS = [
+  "donut",
+  "donut_vertical",
+  "compact",
+  "bar",
+  "stacked",
+  "horizontal_list",
+  "vertical_list",
+  "grid",
+] as const;
+
+export type LangChartLayout = (typeof LANG_CHART_LAYOUTS)[number];
+
 export interface LangChartOptions {
   hide_border: boolean;
   hide_title: boolean;
   custom_title?: string;
   border_radius: number;
   max_langs: number; // max languages to show (default 8)
-  layout:
-    | "donut"
-    | "donut_vertical"
-    | "compact"
-    | "bar"
-    | "stacked"
-    | "horizontal_list"
-    | "vertical_list"
-    | "grid"; // chart style
+  layout: LangChartLayout;
 }
 
 export type StatKey =


### PR DESCRIPTION
## Summary

This PR introduces three new **Language Chart** layouts:

### 1. Donut Language Chart

<img width="466" height="206" alt="Donut Language Chart" src="https://github.com/user-attachments/assets/fe9c1aff-4bb9-4240-b700-3c7421e4c6f1" />

### 2. Donut Vertical Language Chart

<img width="307" height="351" alt="Donut Vertical Language Chart" src="https://github.com/user-attachments/assets/84c93fa5-3077-4573-a47c-d77cbf8eaf01" />

### 3. Compact Language Chart

<img width="303" height="146" alt="Compact Language Chart" src="https://github.com/user-attachments/assets/91cb124d-7563-426f-8e95-03accf69c5fb" />

### Additional Changes
- Updated frontend layout picker for Languages
- Updated README.md for the new layouts.
- Updated parameters to support the newly added layouts.

